### PR TITLE
user_show - avoid lots of db access pre-CKAN 2.3

### DIFF
--- a/ckanext/issues/controller/show.py
+++ b/ckanext/issues/controller/show.py
@@ -37,8 +37,8 @@ def _get_assigned_user(assignee_id, session):
     # we only need the basic properties of the user, not its datasets etc
     if toolkit.check_ckan_version(min_version='2.3'):
         # these are the defaults, but just in case...
-        data_dict = {'include_datasets': False,
-                     'include_num_followers': False}
+        data_dict.update({'include_datasets': False,
+                          'include_num_followers': False})
     else:
         context = {'return_minimal': True}
     try:

--- a/ckanext/issues/controller/show.py
+++ b/ckanext/issues/controller/show.py
@@ -13,7 +13,7 @@ def show(issue_id, dataset_id, session):
         'No description provided')
     comment_count = len(issueobj.comments)
 
-    issue['assignee'] = _get_assigned_user(issue['assignee_id'])
+    issue['assignee'] = _get_assigned_user(issue['assignee_id'], session)
 
     return {
         'issue': issue,
@@ -31,8 +31,17 @@ def _validate_show(issue_id, dataset_id, session,
     return issue_id
 
 
-def _get_assigned_user(assignee_id):
+def _get_assigned_user(assignee_id, session):
+    context = {'session': session, 'model': cmodel}
+    data_dict = {'id': assignee_id}
+    # we only need the basic properties of the user, not its datasets etc
+    if toolkit.check_ckan_version(min_version='2.3'):
+        # these are the defaults, but just in case...
+        data_dict = {'include_datasets': False,
+                     'include_num_followers': False}
+    else:
+        context = {'return_minimal': True}
     try:
-        return toolkit.get_action('user_show')(data_dict={'id': assignee_id})
+        return toolkit.get_action('user_show')(context, data_dict)
     except toolkit.ObjectNotFound:
         return None

--- a/ckanext/issues/tests/controllers/test_assign.py
+++ b/ckanext/issues/tests/controllers/test_assign.py
@@ -15,7 +15,7 @@ class TestAssign(helpers.FunctionalTestBase):
         self.owner = factories.User()
         self.org = factories.Organization(user=self.owner)
         self.dataset = factories.Dataset(user=self.owner,
-                                         owner_org=self.org['name'])
+                                         owner_org=self.org['id'])
         self.issue = issue_factories.Issue(user=self.owner,
                                            user_id=self.owner['id'],
                                            dataset_id=self.dataset['id'])


### PR DESCRIPTION
For pre-CKAN 2.3, ensure that user_show doesn't make lots of db accesses to get all the owning users' packages etc. when displaying an issue.
e.g. at /dataset/annakarenina/issues/1