### PR TITLE
Tidy start-up commit and messages.

### DIFF
--- a/ckanext/issues/model.py
+++ b/ckanext/issues/model.py
@@ -33,10 +33,15 @@ def setup():
         define_issue_tables()
         log.debug('Issue tables defined in memory')
 
-    if model.package_table.exists():
+    if not model.package_table.exists():
+        # during tests?
+        return
+
+    if not issue_table.exists():
         issue_category_table.create(checkfirst=True)
         issue_table.create(checkfirst=True)
         issue_comment_table.create(checkfirst=True)
+        log.debug('Issue tables created')
 
         # add default categories if they don't already exist
         session = model.meta.Session()
@@ -49,10 +54,11 @@ def setup():
                 category = IssueCategory(category_name)
                 category.description = category_desc
                 session.add(category)
-        session.commit()
-        log.debug('Issue tables created')
+        if session.new:
+            log.debug('Issue categories created')
+            session.commit()
     else:
-        log.debug('Issue Extension tables already exist')
+        log.debug('Issue tables already exist')
 
 ISSUE_CATEGORY_NAME_MAX_LENGTH = 100
 DEFAULT_CATEGORIES = {u"broken-resource-link": "Broken data link",


### PR DESCRIPTION
Fix bug where it would create an blank commit every time CKAN starts up, followed by activity error (on latest ckan):
```
2015-07-07 10:29:45,983 DEBUG [ckanext.issues.model] Issue tables defined in memory
2015-07-07 10:29:46,082 DEBUG [ckan.lib.activity_streams_session_extension] session had no _object_cache or no revision, skipping this commit
Traceback (most recent call last):
  File "/src/ckan/ckan/lib/activity_streams_session_extension.py", line 51, in before_commit
    object_cache = session._object_cache
AttributeError: 'Session' object has no attribute '_object_cache'
2015-07-07 10:29:46,088 DEBUG [ckanext.issues.model] Issue tables created
```
After this change the start-up messages are:
```
2015-07-07 10:54:28,793 DEBUG [ckanext.issues.model] Issue tables defined in memory
2015-07-07 10:54:28,797 DEBUG [ckanext.issues.model] Issue tables already exist
```